### PR TITLE
Fix regexp commas truncating in a simple way

### DIFF
--- a/src/matcher.php
+++ b/src/matcher.php
@@ -20,7 +20,8 @@ function matcher($value, $pattern)
     if (($p = ltrim($pattern, ':')) != $pattern) foreach (explode(' ', $p) as $name) {
         if (substr($name, -1) == ')') {
             list($name, $args) = explode('(', $name);
-            $args = explode(',', rtrim($args, ')'));
+            $args = [rtrim($args, ')')];
+            if ($name!='regexp') $args = explode(',', $args[0]);
         }
         if (is_callable(rules($name))) {
             if (!call_user_func_array(rules($name), array_merge([$value], $args))) {


### PR DESCRIPTION
On actual library version regex expression literals using commas was assuming as diferents arguments exploding by "," character but preg_match function only need a configuration argument, the pattern.

With this PR the argument splitting is prevented for regexp rule.
Resolves issue #2 and is an alternative to PR #3 